### PR TITLE
Better session helper config naming and defaults

### DIFF
--- a/src/modules/__tests__/configureSession.js
+++ b/src/modules/__tests__/configureSession.js
@@ -16,7 +16,7 @@ const request = axios.create({
 })
 
 const createSession = configureSession({
-  sessionNamespace: 'test',
+  sessionName: 'versal-test',
   sessionSecret: 'tset',
   sessionExpiresMs: 1000
 })

--- a/src/modules/configureSession.js
+++ b/src/modules/configureSession.js
@@ -24,22 +24,23 @@ const getSessionFacade = req => ({
 })
 
 const configureSession = ({
-  sessionNamespace,
+  sessionName,
+  sessionStorePrefix,
   sessionCacheUri,
   sessionSecret,
   sessionExpiresMs
 }) => {
   let store
-  if (sessionNamespace && sessionCacheUri) {
+  if (sessionCacheUri) {
     store = new MemcachedStore({
-      prefix: `${sessionNamespace}-session-`,
+      prefix: sessionStorePrefix,
       host: sessionCacheUri
     })
   }
 
   const middleware = session({
     store,
-    name: `versal-${sessionNamespace}`,
+    name: sessionName,
     secret: sessionSecret,
     resave: false,
     saveUninitialized: true,


### PR DESCRIPTION
Less opinionated naming. We need this internally so we can conform to legacy cookie and session store naming and gains flexibility overall without making it harder to work with.