### PR TITLE
Fix memcached store hosts parameter

### DIFF
--- a/src/modules/configureSession.js
+++ b/src/modules/configureSession.js
@@ -34,7 +34,7 @@ const configureSession = ({
   if (sessionCacheUri) {
     store = new MemcachedStore({
       prefix: sessionStorePrefix,
-      host: sessionCacheUri
+      hosts: sessionCacheUri
     })
   }
 


### PR DESCRIPTION
Change MemcachedStore `hosts` parameter so it will not use default value and hence ignore `sessionCacheUri` sub-app config value.

See https://github.com/balor/connect-memcached for syntax.